### PR TITLE
Change OFFSET/LIMIT to use Long in place of Int

### DIFF
--- a/core/src/main/scala/scoobie/ast.scala
+++ b/core/src/main/scala/scoobie/ast.scala
@@ -104,8 +104,8 @@ object ast {
                                 filter: QueryComparison[F],
                                 sorts: List[QuerySort[F]],
                                 groupings: List[QuerySort[F]],
-                                offset: Option[Int],
-                                limit: Option[Int]
+                                offset: Option[Long],
+                                limit: Option[Long]
   ) extends QueryExpression[F] with QueryValue[F]
 
   case class ModifyField[F[_]](key: QueryPath[F], value: QueryValue[F])

--- a/plugins/dialects/ansi-sql/src/main/scala/scoobie/doobie/doo/ansi/SqlInterpreter.scala
+++ b/plugins/dialects/ansi-sql/src/main/scala/scoobie/doobie/doo/ansi/SqlInterpreter.scala
@@ -15,12 +15,12 @@ object SqlInterpreter {
   * @param escapeFieldWith
   * @param lifter Something that knows how to use the typeclass F to produce values of B.
   * @param sqlFragmentInterpreter An implementation of F[_] that should not do any augmentation to the query string provided.
-  * @param intInterpreter An implementation of F[_] for handling ints.
+  * @param longInterpreter An implementation of F[_] for handling longs.
   * @tparam F The typeclass used to lift values in to the context of B.  Most important inside of the QueryParameter case of the reduceValue function.
   * @tparam B A type we can produce using an value for F[A] and a value for A. B must be semigroupal.
   */
 case class SqlInterpreter[F[_], B: Semigroup](escapeFieldWith: String)
-                                             (implicit lifter: SqlQueryLifter[F,B], sqlFragmentInterpreter: F[LiteralQueryString], intInterpreter: F[Int]) {
+                                             (implicit lifter: SqlQueryLifter[F,B], sqlFragmentInterpreter: F[LiteralQueryString], longInterpreter: F[Long]) {
   implicit class SqlLitInterpolator(val s: StringContext) {
     def litSql(params: String*): B =
       evaluatedLitSql(s.standardInterpolator(identity, params))
@@ -126,8 +126,8 @@ case class SqlInterpreter[F[_], B: Semigroup](escapeFieldWith: String)
 
         val sqlTable = reduceProjection(table)
 
-        val sqlOffset = offset.map(n => litSql"OFFSET " |+| lifter.liftValue(n, intInterpreter) |+| litSql" ").getOrElse(litSql"")
-        val sqlLimit = limit.map(n => litSql"LIMIT " |+| lifter.liftValue(n, intInterpreter) |+| litSql" ").getOrElse(litSql"")
+        val sqlOffset = offset.map(n => litSql"OFFSET " |+| lifter.liftValue(n, longInterpreter) |+| litSql" ").getOrElse(litSql"")
+        val sqlLimit = limit.map(n => litSql"LIMIT " |+| lifter.liftValue(n, longInterpreter) |+| litSql" ").getOrElse(litSql"")
 
         litSql"SELECT " |+| sqlProjections |+| litSql"FROM " |+| sqlTable |+| sqlJoins |+| sqlFilter |+| sqlSorts |+| sqlGroups |+| sqlLimit |+| sqlOffset
 

--- a/plugins/doobie/doobie-postgres/src/it/scala/scoobie/doobie/PostgresTest.scala
+++ b/plugins/doobie/doobie-postgres/src/it/scala/scoobie/doobie/PostgresTest.scala
@@ -1,126 +1,149 @@
 package scoobie.doobie.doo
 
 import _root_.doobie.imports._
-import org.specs2._
+import doobie.specs2.imports._
 import scoobie.doobie.doo.postgres._
-import scoobie.snacks.mild.sql
 import scoobie.snacks.mild.sql._
+import org.specs2.mutable.Specification
 
 import scalaz.NonEmptyList
-import scalaz.concurrent.Task
 
 /**
   * Created by jbarber on 5/14/16.
   */
-class PostgresTest extends Specification {
+object PostgresTest extends Specification with AnalysisSpec {
 
   implicit val logger = scoobie.doobie.log.verboseTestLogger
 
-  val xa: Transactor[Task] = DriverManagerTransactor[Task](
+  override val transactor: Transactor[IOLite] = DriverManagerTransactor[IOLite](
     "org.postgresql.Driver", "jdbc:postgresql:world", "postgres", "postgres"
   )
 
-  def is =
-    s2"""
+  case class Country(name: String, gnp: Option[BigDecimal], code: String)
 
-  Building queries should work properly
-    semi-complex select                               $semiComplexSelectResult
-    where in select                                   $selectWhereInResult
-    record life-cycle                                 ${endToEndTest.transact(xa).unsafePerformSync}
-                                                      """
-
-  case class Country(name: String, gnp: Int, code: String)
-
-  lazy val semiComplexSelect =
+  lazy val semiComplexSelectQuery: Query0[(Country, Country)] =
     (
-      select(
+      select (
         p"c1.name",
-        (p"c1.gnp" + 5) as "c1gnp",
+        (p"c1.gnp" + BigDecimal(5)) as "c1gnp",
         p"c1.code",
         p"c2.name",
         p"c2.gnp",
         p"c2.code"
-      ) from (
-        p"country" as "c1"
-      ) innerJoin (
-        p"country" as "c2" on (
-          p"c2.code" === func"reverse" (p"c1.code")
+      ) from (p"country" as "c1")
+        innerJoin (
+          p"country" as "c2" on (
+            p"c2.code" === func"reverse" (p"c1.code")
+          )
         )
-      ) where (
-        sql.not(p"c2.code" === "USA") and
-        p"c1.lifeexpectancy" > 50
-      )
-    ).build
-      .query[(Country, Country)]
-      .list
-      .transact(xa)
-      .unsafePerformSync
+        where (
+          (p"c2.code" !== "USA")
+            and
+          (p"c1.lifeexpectancy" > 50F)
+        )
+        orderBy p"c1.name".asc
+        limit 5
+        offset 2
+    ).build.query[(Country, Country)]
 
-  lazy val selectWhereIn = {
-    val codes = NonEmptyList("TUV", "YUG")
+
+  def selectWhereInQuery(codes: NonEmptyList[String]): Query0[String] =
     (
-      select(p"name") from p"country" where (p"code" in ("USA", "BRA", codes))
-    ).build
-      .query[String]
-      .list
-      .transact(xa)
-      .unsafePerformSync
-  }
+      select ( p"name" )
+        from p"country"
+        where (p"code" in ("USA", "BRA", codes))
+    ).build.query[String]
 
-  lazy val endToEndTest = {
-    for {
-      inserted <- (insertInto(p"city") values(
-                    p"id" ==> 4080,
-                    p"name" ==> "test",
-                    p"countrycode" ==> "SHT",
-                    p"district" ==> "District of unlawful testing",
-                    p"population" ==> 1
-                  )).update.run
+  lazy val insertCityQuery: Update0 =
+    (
+      insertInto(p"city") values(
+        p"id" ==> 4080,
+        p"name" ==> "test",
+        p"countrycode" ==> "SHT",
+        p"district" ==> "District of unlawful testing",
+        p"population" ==> 1
+      )
+    ).build.update
 
-      select1 <- (select(p"district") from p"city" where (p"id" === 4080))
-                    .build
-                    .query[String]
-                    .option
+  lazy val selectDistrictQuery: Query0[String] =
+    (
+      select ( p"district" )
+        from p"city"
+        where (p"id" === 4080)
+    ).build.query[String]
 
-      updated <- (update(p"city") set (p"population" ==> 10) where (p"id" === 4080))
-                    .build
-                    .update
-                    .run
+  lazy val updateCityPopulationQuery: Update0 =
+    (
+      update ( p"city" )
+        set (p"population" ==> 10)
+        where (p"id" === 4080)
+    ).build.update
 
-      select2 <- (select(p"population") from p"city" where (p"id" === 4080))
-                    .build
-                    .query[Int]
-                    .option
+  lazy val selectCityPopulationQuery: Query0[Int] =
+    (
+      select ( p"population" )
+        from p"city"
+        where (p"id" === 4080)
+    ).build.query[Int]
 
-      deleted <- (deleteFrom(p"city") where (p"id" === 4080))
-                    .update
-                    .run
+  lazy val deleteCityQuery: Update0 =
+    (
+      deleteFrom ( p"city" )
+        where (p"id" === 4080)
+    ).build.update
 
-      select3 <- (select(p"population") from p"city" where (p"id" === 4080))
-                    .build
-                    .query[Int]
-                    .option
-    } yield {
-      inserted must beEqualTo(1)
-      select1  must beEqualTo(Some("District of unlawful testing"))
-      updated  must beEqualTo(1)
-      select2  must beEqualTo(Some(10))
-      deleted  must beEqualTo(1)
-      select3  must beEqualTo(None)
+  "Built Queries" should {
+    "pass type checks" in {
+      "semi-complex select" in check(semiComplexSelectQuery)
+      "select where in" in check(selectWhereInQuery(NonEmptyList("a", "b")))
+      "insert city" in check(insertCityQuery)
+      "select district" in check(selectDistrictQuery)
+      "update population" in check(updateCityPopulationQuery)
+      "select population" in check(selectCityPopulationQuery)
+      "delete city" in check(deleteCityQuery)
     }
   }
 
-//    id integer NO
-//    name varchar
-//    countrycode c
-//    district varc
-//    population in
+  "Running Built Queries" should {
+    "generate correct results" in {
+      "semi-complex select" in {
+        val result = semiComplexSelectQuery
+          .list
+          .transact(transactor)
+          .unsafePerformIO
 
-  def semiComplexSelectResult = {
-    semiComplexSelect must haveSize(10)
-  }
+          result must haveSize(5)
+          result.headOption.map(_._1.code) must beSome("GUY")
+          result.headOption.map(_._2.code) must beSome("YUG")
+          result.lastOption.map(_._1.code) must beSome("SUR")
+          result.lastOption.map(_._2.code) must beSome("RUS")
+      }
+      "select where in" in {
+        val result =
+          selectWhereInQuery(NonEmptyList("TUV", "YUG"))
+            .list
+            .transact(transactor)
+            .unsafePerformIO
 
-  def selectWhereInResult = {
-    selectWhereIn must haveSize(4)
+        result must haveSize(4)
+      }
+      "end to end" in {
+        (for {
+          inserted <- insertCityQuery.run
+          select1 <- selectDistrictQuery.option
+          updated <- updateCityPopulationQuery.run
+          select2 <- selectCityPopulationQuery.option
+          deleted <- deleteCityQuery.run
+          select3 <- selectCityPopulationQuery.option
+        } yield {
+          inserted must beEqualTo(1)
+          select1  must beSome("District of unlawful testing")
+          updated  must beEqualTo(1)
+          select2  must beSome(10)
+          deleted  must beEqualTo(1)
+          select3  must beNone
+        }).transact(transactor).unsafePerformIO
+      }
+    }
   }
 }

--- a/plugins/dsl/mild-sql-dsl/src/main/scala/scoobie/snacks/mild/sql/query/select.scala
+++ b/plugins/dsl/mild-sql-dsl/src/main/scala/scoobie/snacks/mild/sql/query/select.scala
@@ -22,8 +22,8 @@ trait select {
                                  filter: QueryComparison[F],
                                  sorts: List[QuerySort[F]],
                                  groupings: List[QuerySort[F]],
-                                 offset: Option[Int],
-                                 limit: Option[Int]
+                                 offset: Option[Long],
+                                 limit: Option[Long]
   ) {
     def leftOuterJoin(tup: (QueryProjection[F], QueryComparison[F])): QueryBuilder[F] =
       this.copy(unions = QueryLeftOuterJoin(tup._1, tup._2) :: unions)
@@ -49,8 +49,8 @@ trait select {
     def orderBy(sorts: QuerySort[F]*) = this.copy(sorts = this.sorts ::: sorts.toList)
     def groupBy(groups: QuerySort[F]*) = this.copy(groupings = this.groupings ::: groups.toList)
 
-    def offset(n: Int): QueryBuilder[F] = this.copy(offset = Some(n))
-    def limit(n: Int): QueryBuilder[F] = this.copy(limit = Some(n))
+    def offset(n: Long): QueryBuilder[F] = this.copy(offset = Some(n))
+    def limit(n: Long): QueryBuilder[F] = this.copy(limit = Some(n))
 
   }
 

--- a/project/ScoobieUtil.scala
+++ b/project/ScoobieUtil.scala
@@ -16,6 +16,7 @@ object ScoobieUtil {
   lazy val doobiePGDriver = "org.tpolecat" %% "doobie-postgres"
   lazy val scalaz = "org.scalaz" %% "scalaz-core" % "7.2.10"
   lazy val specs = "org.specs2" %% "specs2-core" % "3.8.8" % "test,it"
+  lazy val doobieSpecs = "org.tpolecat" %% "doobie-specs2"
   lazy val genPackageInfo = settingKey[Boolean]("Should we generate package info?")
 
   lazy val noPublishSettings = Seq(
@@ -176,7 +177,7 @@ object ScoobieUtil {
       scoobieSettings ++ Seq(
         name := scoobieArtifactName,
         description := projectDescription,
-        libraryDependencies ++= doobieArtifact.map(_ % doobieVersion).toList ++ Seq(specs),
+        libraryDependencies ++= doobieArtifact.map(_ % doobieVersion).toList ++ Seq(specs, doobieSpecs % doobieVersion % "it"),
         packageInfoGenerator(s"scoobie.doobie.$doobiePluginName", scoobieArtifactName),
         target := file(sourceDir).getAbsoluteFile / s"target$versionNoDots"
       )


### PR DESCRIPTION
I use doobie-scalatest in one of my own projects and have just intergrated scoobie to generate `Query0` `Update0` e.t.c.

I found that all my tests that used LIMIT were now failing tests as the metadata was expecting a `Long` to match BIGINT and were instead getting an `Int` because of this library.

```
? P02 Int   ?  BIGINT (int8)
[info]       - Int is not coercible to BIGINT (int8) according to the JDBC specification. Fix
[info]         this by changing the schema type to INTEGER, or the Scala type to Long.
```

I've modified `limit` and `offset` to instead accept a `Long`.

I've also modified `PostgresTest` to typecheck each SQL query using doobie-specs2 and fixed the data types in queries/`Country` to match expected types. I couldn't do the same for `MysqlTest` however as the JDBC driver doesn't contain metadata types for parameters so I've left it as-is